### PR TITLE
Update GA reproduction methods to support single_uprate and eq_uprate calc types

### DIFF
--- a/ravenframework/Optimizers/crossOverOperators/crossovers.py
+++ b/ravenframework/Optimizers/crossOverOperators/crossovers.py
@@ -104,7 +104,7 @@ def uniformCrossover(parents,**kwargs):
   if any("prlodata" in sublist for sublist in kwargs["files"]):
     inpfile = [sublist[-1] for sublist in kwargs["files"] if sublist[1]=='prlodata'][0]
     EQObject = EQChecker(inpfile.getPath()+inpfile.getFilename())
-    EQFlag = True if EQObject.prloData.calculationType == "eq_cycle" else False
+    EQFlag = True if EQObject.prloData.calculationType in ["eq_cycle","eq_uprate"] else False
 
   index = 0
   parentsPairs = list(combinations(parents,2))

--- a/ravenframework/Optimizers/mutators/mutators.py
+++ b/ravenframework/Optimizers/mutators/mutators.py
@@ -77,7 +77,7 @@ def swapMutatorEQ(offSprings, distDict, **kwargs):
     inpfile = [sublist[-1] for sublist in kwargs["files"] if sublist[1]=='prlodata'][0]
     EQObject = EQChecker(inpfile.getPath()+inpfile.getFilename())
     symMult = EQObject.prloData.symmetricMultiplicity
-    EQFlag = True if EQObject.prloData.calculationType == "eq_cycle" else False
+    EQFlag = True if EQObject.prloData.calculationType in ["eq_cycle","eq_uprate"] else False
   if not EQFlag:
     raise ValueError("'swapMutatorEQ' is only appropriate of the 'eq_cycle' calculationType.")
 

--- a/ravenframework/utils/EQChecker.py
+++ b/ravenframework/utils/EQChecker.py
@@ -12,7 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
+import os, re
 import numpy as np
 from xml.etree import ElementTree as ET
 from ravenframework.utils import randomUtils
@@ -85,7 +85,7 @@ class EQChecker():
       This is a trimmed down version of the PARCSv345InpGen.PRLODataParser class.
       #!NOTE(rollnk): it is likely more elegant to have a single, external version of this class rather than redefine it repeatedly.
     """
-    def __init__(self, inputFile):
+    def __init__(self, inputFile, verbosity="full"):
       """
         Constructor.
         @ In, inputFile, string, xml PARCSv345 parameters file
@@ -97,36 +97,68 @@ class EQChecker():
 
       # Parse user-provided data from XML file
       #!TODO: define default values for missing params; list expected formats/units here.
-      self.calculationType = '_'.join(root.find('calculationType').text.strip().lower().split())
-      self.numAssemblies = int(root.find('numAssemblies').text.strip())
-      self.numBatches = int(root.find('numBatches').text.strip())
-      self.feedBatchSizeLimits = root.find('feedBatchSizeLimits').text.strip() if root.find('feedBatchSizeLimits') is not None else None
-      self.colLabels = root.find('colLabels').text.strip()
-      self.rowLabels = root.find('rowLabels').text.strip()
-      self.geometry = root.find('geometry').text.strip()
-      self.coreShape = root.find('coreShape').text
-      self.faDict = []
-      for fa in root.iter('FA'):
-        self.faDict.append(fa.attrib)
-      self.numTypes = len([fa for fa in self.faDict if fa['type'] == 'fuel'])
-      self.xsDict =[]
-      for xs in root.iter('XS'):
-        self.xsDict.append(xs.attrib)
+      if verbosity in ['calcType','full','reduced']:
+        self.calculationType = '_'.join(root.find('calculationType').text.strip().lower().split()) if root.find('calculationType') is not None else "single_cycle"
+      if verbosity in ['full','reduced']:
+        self.numAssemblies = int(root.find('numAssemblies').text.strip())
+        self.numBatches = int(root.find('numBatches').text.strip())
+        self.feedBatchSizeLimits = root.find('feedBatchSizeLimits').text.strip() if root.find('feedBatchSizeLimits') is not None else None
+        self.colLabels = root.find('colLabels').text.strip()
+        self.rowLabels = root.find('rowLabels').text.strip()
+        self.geometry = root.find('geometry').text.strip()
+        #!self.coreShape = root.find('coreShape').text # DEPRECATED
+        self.coreShape = re.sub(r"\d{2}",'1',re.sub(r"r\d",'0',self.geometry.replace('00','  ')))
+        self.faDict = []
+        for fa in root.iter('FA'):
+          self.faDict.append(fa.attrib)
+        self.numTypes = len([fa for fa in self.faDict if fa['type'] == 'fuel'])
+        self.xsDict =[]
+        for xs in root.iter('XS'):
+          self.xsDict.append(xs.attrib)
 
-      # Resolve calculated values from user-provided data
-      fuelMap = [int(s) for s in self.geometry.strip().split() if s.isdigit()]
-      self.solnLen = max(fuelMap)
-      self.symmetricMultiplicity = {i:fuelMap.count(i) for i in fuelMap}
-
-      if not self.feedBatchSizeLimits:
-        self.feedBatchSizeLimits = (np.ceil(self.numAssemblies/self.numBatches),self.numAssemblies) # logical extremes for feed batch size
-      else:
-        self.feedBatchSizeLimits = tuple([int(val.strip()) for val in self.feedBatchSizeLimits.replace(',',' ').split()])
-        if len(self.feedBatchSizeLimits) == 1:
-          # if only one value is given, assume that value is the maximum limit.
-          self.feedBatchSizeLimits = (np.ceil(self.numAssemblies/self.numBatches),self.feedBatchSizeLimits[0])
+        # Resolve calculated values from user-provided data
+        if not self.feedBatchSizeLimits:
+          self.feedBatchSizeLimits = (np.ceil(self.numAssemblies/self.numBatches),self.numAssemblies) # logical extremes for feed batch size
         else:
-          self.feedBatchSizeLimits = (self.feedBatchSizeLimits[0],self.feedBatchSizeLimits[-1]) #ensure only two values are provided.
+          self.feedBatchSizeLimits = tuple([int(val.strip()) for val in self.feedBatchSizeLimits.replace(',',' ').split()])
+          if len(self.feedBatchSizeLimits) == 1:
+            # if only one value is given, assume that value is the maximum limit.
+            self.feedBatchSizeLimits = (np.ceil(self.numAssemblies/self.numBatches),self.feedBatchSizeLimits[0])
+          else:
+            self.feedBatchSizeLimits = (self.feedBatchSizeLimits[0],self.feedBatchSizeLimits[-1]) #ensure only two values are provided.
+
+      if verbosity in ['full']:
+        self.useTemplate = self.str_to_bool(root.find('useTemplate').text.strip()) if root.find('useTemplate') is not None else False
+        self.THFlag = self.str_to_bool(root.find('THFlag').text.strip()) if root.find('THFlag') is not None else False
+        self.power = float(root.find('power').text.strip()) if root.find('power') is not None else 100.0
+        self.coreType = root.find('coreType').text.strip().upper() if root.find('coreType') is not None else "PWR"
+        self.initialExposure = float(root.find('initialExposure').text.strip()) if root.find('initialExposure') is not None else 0.00
+        self.initialBoron = int(root.find('initialBoron').text.strip())
+        self.pinPowerRecFlag = self.str_to_bool(root.find('pinPowerRecFlag').text.strip())
+        self.numAxial = int(root.find('numAxial').text.strip())
+        self.gridX = root.find('gridX').text.strip()
+        self.gridY = root.find('gridY').text.strip()
+        self.gridZ = root.find('gridZ').text.strip()
+        self.neutmeshX = root.find('neutmeshX').text.strip()
+        self.neutmeshY = root.find('neutmeshY').text.strip()
+        self.BC = root.find('BC').text.strip()
+        self.faPower = float(root.find('faPower').text.strip())
+        self.faPitch = float(root.find('faPitch').text.strip())
+        self.inletTemp = float(root.find('inletTemp').text.strip())
+        self.flow = float(root.find('flow').text.strip()) #!TODO: I believe this is mass flow; doublecheck
+        self.depHistory = root.find('depHistory').text.strip()
+        self.inpHistFile = root.find('inpHistFile').text.strip() if root.find('inpHistFile') is not None else None
+        #!self.xsDir = root.find('xsDir').text.strip() #!TODO(rollnk):deprecated, remove.
+        self.xsLib = root.find('xsLib').text.strip()
+        self.xsExtension = root.find('xsExtension').text.strip()
+
+    def str_to_bool(self,string):
+      if string.lower() in ['t','true','1','yes','y']:
+        return True
+      elif string.lower() in ['f','false','0','no','n']:
+        return False
+      else:
+        raise ValueError(f"Failed to convert string '{string}' to boolean.")
 
   def decodeFAID(self,faID,solnLen,numBatches):
     """


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What are the significant changes in functionality due to this change request?

Update GA reproduction methods to support single_uprate and eq_uprate calc types

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [ ] 1. Review all computer code.
- [ ] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [ ] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [ ] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [ ] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [ ] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [ ] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [ ] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [ ] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

