### PR TITLE
Opt restart update documentation and SSChecker

### DIFF
--- a/doc/user_guide/optimizing.tex
+++ b/doc/user_guide/optimizing.tex
@@ -342,6 +342,67 @@ resolution of valleys, while too small a shrink factor results in many unnecessa
 % Note these are only guidelines; individual models may behave differently and require more or less resamples to
 % provide a clear optimization path.
 
+\subsection{Checkpoint and Restart} \label{subsec:opt checkpoint restart}
+Long optimization runs may be interrupted before convergence due to wall-time limits, system
+failures, or other external factors.  RAVEN's checkpoint/restart system allows an optimizer to
+save its state periodically and resume from that saved state in a subsequent run, avoiding the
+need to start over.
+
+\subsubsection{Writing Checkpoints}
+To enable checkpoint writing, add \xmlNode{writeCheckpoint} inside the \xmlNode{samplerInit}
+block of your optimizer:
+\begin{lstlisting}[style=XML]
+<samplerInit>
+  <limit>500</limit>
+  <writeCheckpoint file="opt_checkpoint.ravenrst" interval="10">True</writeCheckpoint>
+</samplerInit>
+\end{lstlisting}
+The two optional attributes are:
+\begin{itemize}
+  \item \xmlAttr{file}: the path for the checkpoint file.  Defaults to
+    \texttt{<optimizerName>.ravenrst} in the working directory if omitted.
+  \item \xmlAttr{interval}: how many completed iterations pass between checkpoint writes.
+    A value of \texttt{1} (the default) writes after every iteration; \texttt{10} writes every
+    tenth iteration.
+\end{itemize}
+The checkpoint file is written in HDF5 format and contains the full optimizer state, including
+variable values, convergence history, and enough metadata to reconstruct the
+\xmlNode{SolutionExport} output.
+
+\subsubsection{Restarting from a Checkpoint}
+To resume an interrupted run, add \xmlNode{restartFrom} to \xmlNode{samplerInit} pointing at
+the checkpoint file produced by the previous run:
+\begin{lstlisting}[style=XML]
+<samplerInit>
+  <limit>500</limit>
+  <writeCheckpoint file="opt_checkpoint.ravenrst" interval="10">True</writeCheckpoint>
+  <restartFrom>opt_checkpoint.ravenrst</restartFrom>
+</samplerInit>
+\end{lstlisting}
+Before restoring state the optimizer validates that the checkpoint is compatible with the current
+input file.  Incompatibilities that raise an error (and therefore prevent the restart) include:
+\begin{itemize}
+  \item a different optimizer type (e.g.\ a \xmlNode{GradientDescent} checkpoint used with a
+    \xmlNode{GeneticAlgorithm} input);
+  \item mismatched variable names or bounds; and
+  \item for \xmlNode{GeneticAlgorithm}, a different population size or multi-objective mode.
+\end{itemize}
+Differences in optimizer \xmlAttr{name} or file version produce warnings but do not prevent the
+restart.  Once the checkpoint is loaded, the \xmlNode{SolutionExport} DataObject is
+pre-populated with the historical solution path so that output CSV files appear continuous
+across the interrupted and resumed runs.
+
+\subsubsection{Typical Workflow}
+\begin{enumerate}
+  \item Run the optimizer with \xmlNode{writeCheckpoint} enabled.  The \texttt{.ravenrst} file
+    is updated at the requested interval throughout the run.
+  \item If the run is interrupted, the most recent checkpoint captures the optimizer state as of
+    the last completed write interval.
+  \item Add \xmlNode{restartFrom} pointing to the checkpoint file and resubmit.  RAVEN will
+    restore the optimizer state and continue from where it left off, respecting the original
+    \xmlNode{limit}.
+\end{enumerate}
+
 \subsection{Functional Constraints} \label{subsec:opt explicit constraint}
 Sometimes an optimization problem has a constrained input space, possibly where there is a tradeoff between
 two inputs.  In this event, RAVEN allows the user to define a \emph{constraint} function, which will cause

--- a/doc/user_manual/generated/optimizer.tex
+++ b/doc/user_manual/generated/optimizer.tex
@@ -143,6 +143,30 @@
           the type of optimization to perform. \xmlString{min} will search for the lowest
           \xmlNode{objective} value, while \xmlString{max} will search for the highest value.
           For multi-objective, this can be a list like min, max.
+
+        \item \xmlNode{writeCheckpoint}: \xmlDesc{boolean, optional},
+          when \xmlString{True}, enables automatic checkpoint writing after each completed optimizer
+          iteration. The optimizer state is written to an HDF5 \texttt{.ravenrst} file that can
+          later be used with \xmlNode{restartFrom} to resume an interrupted run.
+          \default{False}
+
+          The \xmlNode{writeCheckpoint} node recognizes the following parameters:
+          \begin{itemize}
+            \item \xmlAttr{file}: \xmlDesc{string, optional},
+              path to the checkpoint output file. If omitted, the file is named
+              \texttt{<optimizerName>.ravenrst} in the working directory.
+            \item \xmlAttr{interval}: \xmlDesc{integer, optional},
+              number of completed iterations between checkpoint writes.
+              \default{1}
+          \end{itemize}
+
+        \item \xmlNode{restartFrom}: \xmlDesc{string, optional},
+          path to an existing \texttt{.ravenrst} checkpoint file from which the optimizer should
+          resume. The optimizer validates that the settings recorded in the checkpoint file are
+          compatible with the current XML configuration (variable names, bounds, and
+          algorithm-specific parameters) before restoring state. The \xmlNode{SolutionExport}
+          DataObject is pre-populated with the historical solution path from the checkpoint so
+          that output files appear continuous.
       \end{itemize}
 
     \item \xmlNode{gradient}:
@@ -1141,6 +1165,30 @@ Simulated Annealing Example:
           the type of optimization to perform. \xmlString{min} will search for the lowest
           \xmlNode{objective} value, while \xmlString{max} will search for the highest value.
           For multi-objective, this can be a list like min, max.
+
+        \item \xmlNode{writeCheckpoint}: \xmlDesc{boolean, optional},
+          when \xmlString{True}, enables automatic checkpoint writing after each completed optimizer
+          iteration. The optimizer state is written to an HDF5 \texttt{.ravenrst} file that can
+          later be used with \xmlNode{restartFrom} to resume an interrupted run.
+          \default{False}
+
+          The \xmlNode{writeCheckpoint} node recognizes the following parameters:
+          \begin{itemize}
+            \item \xmlAttr{file}: \xmlDesc{string, optional},
+              path to the checkpoint output file. If omitted, the file is named
+              \texttt{<optimizerName>.ravenrst} in the working directory.
+            \item \xmlAttr{interval}: \xmlDesc{integer, optional},
+              number of completed iterations between checkpoint writes.
+              \default{1}
+          \end{itemize}
+
+        \item \xmlNode{restartFrom}: \xmlDesc{string, optional},
+          path to an existing \texttt{.ravenrst} checkpoint file from which the optimizer should
+          resume. The optimizer validates that the settings recorded in the checkpoint file are
+          compatible with the current XML configuration (variable names, bounds, population size,
+          and multi-objective mode) before restoring state. The \xmlNode{SolutionExport}
+          DataObject is pre-populated with the historical solution path from the checkpoint so
+          that output files appear continuous.
       \end{itemize}
 
     \item \xmlNode{GAparams}:

--- a/ravenframework/utils/SSChecker.py
+++ b/ravenframework/utils/SSChecker.py
@@ -120,7 +120,7 @@ class _PRLOCheckerBase():
     # decode location
     locNum = int(np.ceil(((faID + 1) % (solnLen*numBatches)) / numBatches))
     if locNum == 0:
-      locNum = int(np.ceil((faID % (solnLen*numBatches)) / numBatches))
+      locNum = solnLen
     # decode batch number
     batchNum = 1 + int(faID % numBatches)
     # decode FA type
@@ -208,6 +208,15 @@ class EQChecker(_PRLOCheckerBase):
         return False, 4
       elif decodedGenomeWithMult[sourceLoc][0][1] - gene[1] != -1: # does batch number increment by 1 after reload?
         return False, 5
+
+  ## Assert: no fresh WABA assembly is placed at a CR bank location
+    wabaTypes = getattr(self.prloData, 'wabaTypes', set())
+    crBankLocSet = getattr(self.prloData, 'crBankLocSet', set())
+    if wabaTypes and crBankLocSet:
+      for i in range(len(genome)):
+        _, batchNum, typeNum = self.decodeFAID(genome[i], self.prloData.solnLen, self.prloData.numBatches)
+        if batchNum == 1 and typeNum in wabaTypes and (i + 1) in crBankLocSet:
+          return False, 6
 
     return True, 0
 
@@ -310,5 +319,14 @@ class SingleCycleChecker(_PRLOCheckerBase):
         return False, 7
     elif not self.prloData.feedBatchSizeLimits[0] <= freshFuelCount <= self.prloData.feedBatchSizeLimits[1]:
       return False, 8
+
+  ## Assert: no fresh WABA assembly is placed at a CR bank location
+    wabaTypes = getattr(self.prloData, 'wabaTypes', set())
+    crBankLocSet = getattr(self.prloData, 'crBankLocSet', set())
+    if wabaTypes and crBankLocSet:
+      for i, gene in enumerate(genome):
+        _, batchNum, typeNum = self.decodeFAID(int(gene), self.prloData.solnLen, self.prloData.numBatches)
+        if batchNum == 1 and typeNum in wabaTypes and (i + 1) in crBankLocSet:
+          return False, 9
 
     return True, 0


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)


##### What are the significant changes in functionality due to this change request?
Opt restart update documentation and SSChecker

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [ ] 1. Review all computer code.
- [ ] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [ ] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [ ] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [ ] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [ ] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [ ] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [ ] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [ ] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

