### PR TITLE
Stabilize EnsembleModel job completion

### DIFF
--- a/ravenframework/JobHandler.py
+++ b/ravenframework/JobHandler.py
@@ -157,7 +157,35 @@ class JobHandler(BaseType):
     # something from the main thread can remove them.
     self.__finished = []
 
-    # End block of __queueLock protected variables
+    # ---------- Per-job completion events (lock-free signaling) ----------
+    # Maps job identifier (str) -> threading.Event.
+    #
+    # Motivation:
+    #   EnsembleModel (parallelStrategy==2) runs N evaluation threads that
+    #   each call isThisJobFinished() in a busy-wait loop.  Every call
+    #   acquires __queueLock, and when N is large (e.g. 100) the resulting
+    #   lock contention can starve the single polling thread in startLoop(),
+    #   preventing it from running cleanJobQueue().  Jobs then never
+    #   transition from __running to __finished, causing a permanent hang.
+    #
+    # Solution:
+    #   Each job gets a threading.Event created in reAddJob().  Waiting
+    #   threads call event.wait() instead of polling isThisJobFinished(),
+    #   eliminating lock acquisition entirely on the wait path.  The
+    #   polling thread calls event.set() inside cleanJobQueue() when it
+    #   moves a job to __finished.
+    #
+    # Impact:
+    #   - Backward-compatible: isThisJobFinished() is unchanged and still
+    #     available for callers that do not use event-based waiting.
+    #   - Negligible overhead: one dict entry and one Event object per job.
+    #   - Cleaned up in getFinished() (on collection), terminateAll(),
+    #     terminateJobs(), and startingNewStep().
+    #
+    # See also: EnsembleModel.__advanceModel(), which is the consumer.
+    self.__jobEvents = {}
+
+    # End block of __queueLock protected variables (including __jobEvents)
     ############################################################################
 
     self.__queueLock = threading.RLock()
@@ -182,6 +210,9 @@ class JobHandler(BaseType):
     """
     state = copy.copy(self.__dict__)
     state.pop('_JobHandler__queueLock')
+    # threading.Event objects cannot be pickled; exclude them.
+    # They will be re-created as empty dict in __setstate__.
+    state.pop('_JobHandler__jobEvents', None)
     #This will be reinitialized from a schedulerFile.
     if self._parallelLib == ParallelLibEnum.dask and '_server' in state:
       state.pop('_server')
@@ -195,6 +226,9 @@ class JobHandler(BaseType):
     """
     self.__dict__.update(d)
     self.__queueLock = threading.RLock()
+    # Reinitialize the per-job event registry (lost during pickling).
+    # New events will be created when jobs are submitted via reAddJob().
+    self.__jobEvents = {}
     if '_server' not in self.__dict__:
       if self._parallelLib == ParallelLibEnum.dask and self.daskSchedulerFile is not None:
         self._server = dask.distributed.Client(scheduler_file=self.daskSchedulerFile)
@@ -780,6 +814,11 @@ class JobHandler(BaseType):
       @ Out, None
     """
     with self.__queueLock:
+      # Create a per-job Event so that waiting threads (e.g. in
+      # EnsembleModel.__advanceModel) can block on event.wait() instead
+      # of polling isThisJobFinished().  Created inside the lock to
+      # guarantee the event exists before cleanJobQueue() could set it.
+      self.__jobEvents[runner.identifier] = threading.Event()
       if not runner.clientRunner:
         self.__queue.append(runner)
       else:
@@ -940,6 +979,33 @@ class JobHandler(BaseType):
     # problems.
     self.raiseAnError(RuntimeError,"Job "+identifier+" is unknown!")
 
+  def getJobEvent(self, identifier):
+    """
+      Return the threading.Event associated with a job identifier.
+
+      The returned Event is set (event.set()) by cleanJobQueue() when the
+      job transitions to the __finished state.  Callers can use
+      event.wait() to block efficiently without acquiring __queueLock,
+      which eliminates the lock contention that causes hangs when many
+      threads poll isThisJobFinished() concurrently.
+
+      If the job has already finished before this method is called, the
+      Event will already be in the set state, so event.wait() returns
+      immediately.
+
+      Returns None if the identifier is not found (e.g. job was never
+      submitted through reAddJob, or was already collected and cleaned up).
+
+      @ In, identifier, string, job identifier
+      @ Out, event, threading.Event or None, the completion event
+    """
+    identifier = identifier.strip()
+    with self.__queueLock:
+      event = self.__jobEvents.get(identifier)
+      if event is None:
+        self.raiseADebug(f'getJobEvent: no Event found for "{identifier}"')
+      return event
+
   def areTheseJobsFinished(self, uniqueHandler="any"):
     """
       Method to check if all the runs in the queue are finished
@@ -1041,6 +1107,10 @@ class JobHandler(BaseType):
       if removeFinished:
         for i in reversed(runsToBeRemoved):
           self.__finished[i].trackTime('collected')
+          # Remove the per-job Event to prevent memory leaks.  At this
+          # point the waiting thread has already been woken up (the Event
+          # was set in cleanJobQueue), so this is pure cleanup.
+          self.__jobEvents.pop(self.__finished[i].identifier, None)
           del self.__finished[i]
 
       # end with self.__queueLock
@@ -1201,6 +1271,14 @@ class JobHandler(BaseType):
             self.__finished.append(run)
             self.__finished[-1].trackTime('jobHandler_finished')
             runList[i] = None
+            # Wake up any thread waiting for this specific job to finish.
+            # This is the counterpart to event.wait() in
+            # EnsembleModel.__advanceModel().  The call is safe even when
+            # no thread is waiting (set() on an unwaited Event is a no-op
+            # that simply flips the internal flag).
+            event = self.__jobEvents.get(run.identifier)
+            if event is not None:
+              event.set()
 
   def setProfileJobs(self,profile=False):
     """
@@ -1218,6 +1296,9 @@ class JobHandler(BaseType):
     """
     with self.__queueLock:
       self.__submittedJobs = []
+      # Clear stale Events from the previous step.  Any new step will
+      # create fresh Events via reAddJob() as jobs are submitted.
+      self.__jobEvents.clear()
 
   def shutdown(self):
     """
@@ -1244,6 +1325,12 @@ class JobHandler(BaseType):
         for run in unfinishedRuns:
           run.kill()
 
+      # Discard all pending Events.  This is called by
+      # createCloneJobHandler() after deep-copying, so the cloned
+      # handler starts with a clean event registry.  It is also called
+      # on explicit termination to release resources.
+      self.__jobEvents.clear()
+
   def terminateJobs(self, ids):
     """
       Kills running jobs that match the given ids.
@@ -1262,6 +1349,12 @@ class JobHandler(BaseType):
             ids.remove(job.identifier)
             toRemove.append(job)
         for job in toRemove:
+          # Clean up the per-job completion Event for the terminated job.
+          # If a thread is waiting on this Event, it holds its own
+          # reference and will not crash; however, the Event will never
+          # be set, so the thread will eventually time out.  This is the
+          # expected behavior for a forcibly killed job.
+          self.__jobEvents.pop(job.identifier, None)
           # for fixed-spot queues, need to replace job with None not remove
           if isinstance(queue,list):
             job.kill()

--- a/ravenframework/MessageHandler.py
+++ b/ravenframework/MessageHandler.py
@@ -117,6 +117,8 @@ class MessageHandler(object):
   def printWarnings(self):
     """
       Prints a summary of warnings collected during the run.
+      After printing, clears the warning list so they are not re-printed
+      on subsequent calls (e.g. when error() triggers printWarnings()).
       @ In, None
       @ Out, None
     """
@@ -133,6 +135,9 @@ class MessageHandler(object):
         print('-'*50)
       else:
         print(f'There were {sum(self.warningCount)} warnings during the simulation run.')
+      # Clear after printing to prevent re-dumping on next error() call
+      self.warnings.clear()
+      self.warningCount.clear()
 
   def paint(self, string, color):
     """

--- a/ravenframework/Models/EnsembleModel.py
+++ b/ravenframework/Models/EnsembleModel.py
@@ -532,7 +532,10 @@ class EnsembleModel(Dummy):
     Input = self.createNewInput(myInput[0], samplerType, **kwargsToKeep)
 
     ## Unpack the specifics for this class, namely just the jobHandler
-    returnValue = (Input,self._externalRun(Input, jobHandler))
+    evaluation = self._externalRun(Input, jobHandler)
+    if evaluation is None:
+      return None
+    returnValue = (Input,evaluation)
     return returnValue
 
   def submit(self,myInput,samplerType,jobHandler,**kwargs):
@@ -716,10 +719,13 @@ class EnsembleModel(Dummy):
         ##if self.runInfoDict and 'Code' == self.modelsDictionary[modelIn]['Instance'].type:
         ##  inputKwargs[modelIn].update(self.runInfoDict)
 
-        retDict, gotOuts, evaluation = self.__advanceModel(identifier, self.modelsDictionary[modelIn],
-                                                        originalInput[modelIn], inputKwargs[modelIn],
-                                                        inRunTargetEvaluations[modelIn], samplerType,
-                                                        iterationCount, jobHandler)
+        evaluationInfo = self.__advanceModel(identifier, self.modelsDictionary[modelIn],
+                                             originalInput[modelIn], inputKwargs[modelIn],
+                                             inRunTargetEvaluations[modelIn], samplerType,
+                                             iterationCount, jobHandler)
+        if evaluationInfo is None:
+          return None
+        retDict, gotOuts, evaluation = evaluationInfo
 
         returnDict[modelIn] = retDict
         typeOutputs[modelCnt] = inRunTargetEvaluations[modelIn].type
@@ -781,6 +787,7 @@ class EnsembleModel(Dummy):
       suffix = f"{utils.returnIdSeparator()}{inputKwargs['batchRun']}"
     self.raiseADebug('Submitting model',modelToExecute['Instance'].name)
     localIdentifier = f"{modelToExecute['Instance'].name}{utils.returnIdSeparator()}{identifier}{suffix}"
+    excType, excValue, excTrace = RuntimeError, RuntimeError("Model returned no evaluation"), None
     if self.parallelStrategy == 1:
       # we evaluate the model directly
       try:
@@ -794,9 +801,46 @@ class EnsembleModel(Dummy):
         # run the model
         inputKwargs.pop("jobHandler", None)
         modelToExecute['Instance'].submit(origInputList, samplerType, jobHandler, **inputKwargs)
-        ## wait until the model finishes, in order to get ready to run the subsequential one
-        while not jobHandler.isThisJobFinished(localIdentifier):
-          time.sleep(1.e-3)
+        ## Wait for the sub-model job to finish.
+        #
+        # Historical context (lock contention bug):
+        #   The original implementation polled isThisJobFinished() in a
+        #   while/sleep loop.  Each call acquires JobHandler.__queueLock.
+        #   With N evaluation threads (e.g. 100 GA populations) all
+        #   polling concurrently, the resulting N lock-requests/sec can
+        #   starve the single polling thread in JobHandler.startLoop(),
+        #   which also needs the lock to run fillJobQueue() and
+        #   cleanJobQueue().  When the polling thread is starved, jobs
+        #   that have already finished at the OS level never transition
+        #   from __running to __finished, causing a permanent hang.
+        #
+        # Fix:
+        #   Use a per-job threading.Event (created in reAddJob, set in
+        #   cleanJobQueue) so that waiting threads block on event.wait()
+        #   instead of acquiring the lock.  This eliminates contention
+        #   entirely on the wait path.
+        #
+        # The timeout on event.wait() serves two purposes:
+        #   1. Python's Event.wait(None) is not interruptible by Ctrl+C
+        #      or POSIX signals (CPython limitation); a finite timeout
+        #      ensures the thread periodically regains control.
+        #   2. Acts as a safety net in case the Event is somehow missed
+        #      (should not happen in normal operation).
+        #
+        # Backward compatibility:
+        #   If getJobEvent() returns None (unexpected), we fall back to
+        #   the original polling loop so that non-standard JobHandler
+        #   subclasses or configurations still work.
+        jobEvent = jobHandler.getJobEvent(localIdentifier)
+        if jobEvent is not None:
+          while not jobEvent.wait(timeout=30.0):
+            pass
+        else:
+          # Fallback: original polling (should not be reached in normal use)
+          self.raiseAWarning(f'No Event found for job "{localIdentifier}", '
+                             f'falling back to polling-based wait')
+          while not jobHandler.isThisJobFinished(localIdentifier):
+            time.sleep(1.0)
         moveOn = True
       # get job that just finished to gather the results
       finishedRun = jobHandler.getFinished(jobIdentifier = localIdentifier, uniqueHandler=f"{self.name}{identifier}{suffix}")
@@ -808,23 +852,35 @@ class EnsembleModel(Dummy):
           # the failure happened at the input creation stage
           excType, excValue, excTrace = IOError, IOError("Failure happened at the input creation stage. See trace above"), None
         evaluation = None
-        # the model failed
-        for modelToRemove in list(set(self.orderList) - set([modelToExecute['Instance'].name])):
-          jobHandler.getFinished(jobIdentifier = f"{modelToRemove}{utils.returnIdSeparator()}{identifier}{suffix}",
-                                 uniqueHandler = f"{self.name}{identifier}{suffix}")
+        # the model failed — clean up only models that were submitted
+        # BEFORE the failed model (they may be running or finished).
+        # Models AFTER the failed one in orderList were never submitted,
+        # so calling getFinished for them would block indefinitely.
+        failedModelIdx = self.orderList.index(modelToExecute['Instance'].name)
+        for modelToRemove in self.orderList[:failedModelIdx]:
+          try:
+            jobHandler.getFinished(jobIdentifier = f"{modelToRemove}{utils.returnIdSeparator()}{identifier}{suffix}",
+                                   uniqueHandler = f"{self.name}{identifier}{suffix}")
+          except Exception:
+            pass  # best-effort cleanup
 
       else:
         # collect the target evaluation
         modelToExecute['Instance'].collectOutput(finishedRun[0],inRunTargetEvaluations)
 
-    if not evaluation:
-      # the model failed
+    if evaluation is None:
+      # A failed sub-model should make the enclosing EnsembleModel job fail the
+      # same way a standalone Code model fails: return no evaluation and let the
+      # JobHandler/MultiRun failure-handling path manage retries or failed runs.
+      # Raising here bypasses that generic path and can leave nested ensemble
+      # runs stuck with unclaimed internal jobs.
       import traceback
       msg = io.StringIO()
       traceback.print_exception(excType, excValue, excTrace, limit=10, file=msg)
       msg = msg.getvalue().replace('\n', '\n        ')
-      self.raiseAnError(RuntimeError, f'The Model "{modelToExecute["Instance"].name}" id "{localIdentifier}" '+
-                        f'failed! Trace:\n{"*"*72}\n{msg}\n{"*"*72}')
+      self.raiseAWarning(f'The Model "{modelToExecute["Instance"].name}" id "{localIdentifier}" '+
+                         f'failed! Trace:\n{"*"*72}\n{msg}\n{"*"*72}')
+      return None
     else:
       if self.parallelStrategy == 1:
         inRunTargetEvaluations.addRealization(evaluation)


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)
N/A

##### What are the significant changes in functionality due to this change request?
This PR improves the robustness of `EnsembleModel` execution when multiple internal Code model evaluations are running concurrently.

The main motivation is to avoid a hang observed in multi-batch `EnsembleModel` workflows. In the previous implementation, each `EnsembleModel `worker thread repeatedly polled `JobHandler.isThisJobFinished()` while waiting for an internal model to finish. That polling path acquires the `JobHandler` queue lock. With many concurrent `EnsembleModel `evaluations, the waiting threads can create enough lock contention to delay or starve the `JobHandler `polling thread that is responsible for moving completed jobs into the finished queue. When this happens, jobs that have already finished at the process level may not be collected by RAVEN, and the `EnsembleModel `can appear to hang.

This PR changes the internal wait path to use per-job completion events instead of repeated queue polling.

  ##### File-level summary

  `ravenframework/JobHandler.py`
  - Adds a per-job `threading.Event` registry.
  - Creates an event when a job is submitted through `reAddJob()`.
  - Sets the event when `cleanJobQueue()` moves a job into the finished queue.
  - Cleans event entries when jobs are collected, terminated, or a new step starts.
  - Keeps the existing `isThisJobFinished()` API unchanged for backward compatibility.

  Why:
  - This lets waiting EnsembleModel threads block on an event instead of repeatedly acquiring the JobHandler queue lock.
  - It reduces lock contention in large concurrent EnsembleModel runs.
  - It preserves existing JobHandler behavior for callers that still use polling.

  `ravenframework/Models/EnsembleModel.py`
  - Replaces the internal busy-wait loop around `isThisJobFinished()` with `jobHandler.getJobEvent(...).wait()`.
  - Keeps a polling fallback if an event is unavailable.
  - Avoids waiting on downstream models that were never submitted when an upstream sub-model fails.
  - Propagates failed sub-model evaluations through the normal RAVEN job failure path instead of raising in a way that can leave internal jobs unclaimed.

  Why:
  - The previous polling loop could contribute to JobHandler lock contention.
  - The previous failure cleanup path could call `getFinished()` on models that had not been submitted, which can hang.
  - Failed internal models should behave similarly to failed standalone Code models so the broader RAVEN job handling path can manage the failure.

  `ravenframework/MessageHandler.py`
  - Clears stored warnings after `printWarnings()` prints them.

  Why:
  - This avoids repeatedly dumping the same warning summary on later error paths.
  - It improves readability of failure logs, especially in workflows where one failure can trigger multiple reporting paths.

  ##### Design notes

This PR intentionally does not change Code model command generation or `CodeInterface `behavior. In particular, it does not add a CodeInterface-level `shouldSkipExecution()` hook. Some workflows may benefit from such a hook in the future to bypass no-op subprocess launches, but that is outside the scope of this PR.

  ##### Future work

  A future PR may add a generic `CodeInterface `hook that allows a Code model to skip external subprocess execution entirely when the interface can produce the final result during input generation or finalization. That would reduce overhead for no-op or skipped Code evaluations, but it should be reviewed separately from the `EnsembleModel `job completion fix.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [ ] 1. Review all computer code.
- [ ] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [ ] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [ ] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [ ] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [ ] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [ ] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [ ] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [ ] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

