### PR TITLE
Feature/raven ga sschecker robustness

### DIFF
--- a/ravenframework/JobHandler.py
+++ b/ravenframework/JobHandler.py
@@ -157,7 +157,35 @@ class JobHandler(BaseType):
     # something from the main thread can remove them.
     self.__finished = []
 
-    # End block of __queueLock protected variables
+    # ---------- Per-job completion events (lock-free signaling) ----------
+    # Maps job identifier (str) -> threading.Event.
+    #
+    # Motivation:
+    #   EnsembleModel (parallelStrategy==2) runs N evaluation threads that
+    #   each call isThisJobFinished() in a busy-wait loop.  Every call
+    #   acquires __queueLock, and when N is large (e.g. 100) the resulting
+    #   lock contention can starve the single polling thread in startLoop(),
+    #   preventing it from running cleanJobQueue().  Jobs then never
+    #   transition from __running to __finished, causing a permanent hang.
+    #
+    # Solution:
+    #   Each job gets a threading.Event created in reAddJob().  Waiting
+    #   threads call event.wait() instead of polling isThisJobFinished(),
+    #   eliminating lock acquisition entirely on the wait path.  The
+    #   polling thread calls event.set() inside cleanJobQueue() when it
+    #   moves a job to __finished.
+    #
+    # Impact:
+    #   - Backward-compatible: isThisJobFinished() is unchanged and still
+    #     available for callers that do not use event-based waiting.
+    #   - Negligible overhead: one dict entry and one Event object per job.
+    #   - Cleaned up in getFinished() (on collection), terminateAll(),
+    #     terminateJobs(), and startingNewStep().
+    #
+    # See also: EnsembleModel.__advanceModel(), which is the consumer.
+    self.__jobEvents = {}
+
+    # End block of __queueLock protected variables (including __jobEvents)
     ############################################################################
 
     self.__queueLock = threading.RLock()
@@ -182,6 +210,9 @@ class JobHandler(BaseType):
     """
     state = copy.copy(self.__dict__)
     state.pop('_JobHandler__queueLock')
+    # threading.Event objects cannot be pickled; exclude them.
+    # They will be re-created as empty dict in __setstate__.
+    state.pop('_JobHandler__jobEvents', None)
     #This will be reinitialized from a schedulerFile.
     if self._parallelLib == ParallelLibEnum.dask and '_server' in state:
       state.pop('_server')
@@ -195,6 +226,9 @@ class JobHandler(BaseType):
     """
     self.__dict__.update(d)
     self.__queueLock = threading.RLock()
+    # Reinitialize the per-job event registry (lost during pickling).
+    # New events will be created when jobs are submitted via reAddJob().
+    self.__jobEvents = {}
     if '_server' not in self.__dict__:
       if self._parallelLib == ParallelLibEnum.dask and self.daskSchedulerFile is not None:
         self._server = dask.distributed.Client(scheduler_file=self.daskSchedulerFile)
@@ -780,6 +814,11 @@ class JobHandler(BaseType):
       @ Out, None
     """
     with self.__queueLock:
+      # Create a per-job Event so that waiting threads (e.g. in
+      # EnsembleModel.__advanceModel) can block on event.wait() instead
+      # of polling isThisJobFinished().  Created inside the lock to
+      # guarantee the event exists before cleanJobQueue() could set it.
+      self.__jobEvents[runner.identifier] = threading.Event()
       if not runner.clientRunner:
         self.__queue.append(runner)
       else:
@@ -940,6 +979,33 @@ class JobHandler(BaseType):
     # problems.
     self.raiseAnError(RuntimeError,"Job "+identifier+" is unknown!")
 
+  def getJobEvent(self, identifier):
+    """
+      Return the threading.Event associated with a job identifier.
+
+      The returned Event is set (event.set()) by cleanJobQueue() when the
+      job transitions to the __finished state.  Callers can use
+      event.wait() to block efficiently without acquiring __queueLock,
+      which eliminates the lock contention that causes hangs when many
+      threads poll isThisJobFinished() concurrently.
+
+      If the job has already finished before this method is called, the
+      Event will already be in the set state, so event.wait() returns
+      immediately.
+
+      Returns None if the identifier is not found (e.g. job was never
+      submitted through reAddJob, or was already collected and cleaned up).
+
+      @ In, identifier, string, job identifier
+      @ Out, event, threading.Event or None, the completion event
+    """
+    identifier = identifier.strip()
+    with self.__queueLock:
+      event = self.__jobEvents.get(identifier)
+      if event is None:
+        self.raiseADebug(f'getJobEvent: no Event found for "{identifier}"')
+      return event
+
   def areTheseJobsFinished(self, uniqueHandler="any"):
     """
       Method to check if all the runs in the queue are finished
@@ -1041,6 +1107,10 @@ class JobHandler(BaseType):
       if removeFinished:
         for i in reversed(runsToBeRemoved):
           self.__finished[i].trackTime('collected')
+          # Remove the per-job Event to prevent memory leaks.  At this
+          # point the waiting thread has already been woken up (the Event
+          # was set in cleanJobQueue), so this is pure cleanup.
+          self.__jobEvents.pop(self.__finished[i].identifier, None)
           del self.__finished[i]
 
       # end with self.__queueLock
@@ -1201,6 +1271,14 @@ class JobHandler(BaseType):
             self.__finished.append(run)
             self.__finished[-1].trackTime('jobHandler_finished')
             runList[i] = None
+            # Wake up any thread waiting for this specific job to finish.
+            # This is the counterpart to event.wait() in
+            # EnsembleModel.__advanceModel().  The call is safe even when
+            # no thread is waiting (set() on an unwaited Event is a no-op
+            # that simply flips the internal flag).
+            event = self.__jobEvents.get(run.identifier)
+            if event is not None:
+              event.set()
 
   def setProfileJobs(self,profile=False):
     """
@@ -1218,6 +1296,9 @@ class JobHandler(BaseType):
     """
     with self.__queueLock:
       self.__submittedJobs = []
+      # Clear stale Events from the previous step.  Any new step will
+      # create fresh Events via reAddJob() as jobs are submitted.
+      self.__jobEvents.clear()
 
   def shutdown(self):
     """
@@ -1244,6 +1325,12 @@ class JobHandler(BaseType):
         for run in unfinishedRuns:
           run.kill()
 
+      # Discard all pending Events.  This is called by
+      # createCloneJobHandler() after deep-copying, so the cloned
+      # handler starts with a clean event registry.  It is also called
+      # on explicit termination to release resources.
+      self.__jobEvents.clear()
+
   def terminateJobs(self, ids):
     """
       Kills running jobs that match the given ids.
@@ -1262,6 +1349,12 @@ class JobHandler(BaseType):
             ids.remove(job.identifier)
             toRemove.append(job)
         for job in toRemove:
+          # Clean up the per-job completion Event for the terminated job.
+          # If a thread is waiting on this Event, it holds its own
+          # reference and will not crash; however, the Event will never
+          # be set, so the thread will eventually time out.  This is the
+          # expected behavior for a forcibly killed job.
+          self.__jobEvents.pop(job.identifier, None)
           # for fixed-spot queues, need to replace job with None not remove
           if isinstance(queue,list):
             job.kill()

--- a/ravenframework/MessageHandler.py
+++ b/ravenframework/MessageHandler.py
@@ -117,6 +117,8 @@ class MessageHandler(object):
   def printWarnings(self):
     """
       Prints a summary of warnings collected during the run.
+      After printing, clears the warning list so they are not re-printed
+      on subsequent calls (e.g. when error() triggers printWarnings()).
       @ In, None
       @ Out, None
     """
@@ -133,6 +135,9 @@ class MessageHandler(object):
         print('-'*50)
       else:
         print(f'There were {sum(self.warningCount)} warnings during the simulation run.')
+      # Clear after printing to prevent re-dumping on next error() call
+      self.warnings.clear()
+      self.warningCount.clear()
 
   def paint(self, string, color):
     """

--- a/ravenframework/Models/EnsembleModel.py
+++ b/ravenframework/Models/EnsembleModel.py
@@ -532,7 +532,10 @@ class EnsembleModel(Dummy):
     Input = self.createNewInput(myInput[0], samplerType, **kwargsToKeep)
 
     ## Unpack the specifics for this class, namely just the jobHandler
-    returnValue = (Input,self._externalRun(Input, jobHandler))
+    evaluation = self._externalRun(Input, jobHandler)
+    if evaluation is None:
+      return None
+    returnValue = (Input,evaluation)
     return returnValue
 
   def submit(self,myInput,samplerType,jobHandler,**kwargs):
@@ -716,10 +719,13 @@ class EnsembleModel(Dummy):
         ##if self.runInfoDict and 'Code' == self.modelsDictionary[modelIn]['Instance'].type:
         ##  inputKwargs[modelIn].update(self.runInfoDict)
 
-        retDict, gotOuts, evaluation = self.__advanceModel(identifier, self.modelsDictionary[modelIn],
-                                                        originalInput[modelIn], inputKwargs[modelIn],
-                                                        inRunTargetEvaluations[modelIn], samplerType,
-                                                        iterationCount, jobHandler)
+        evaluationInfo = self.__advanceModel(identifier, self.modelsDictionary[modelIn],
+                                             originalInput[modelIn], inputKwargs[modelIn],
+                                             inRunTargetEvaluations[modelIn], samplerType,
+                                             iterationCount, jobHandler)
+        if evaluationInfo is None:
+          return None
+        retDict, gotOuts, evaluation = evaluationInfo
 
         returnDict[modelIn] = retDict
         typeOutputs[modelCnt] = inRunTargetEvaluations[modelIn].type
@@ -781,6 +787,7 @@ class EnsembleModel(Dummy):
       suffix = f"{utils.returnIdSeparator()}{inputKwargs['batchRun']}"
     self.raiseADebug('Submitting model',modelToExecute['Instance'].name)
     localIdentifier = f"{modelToExecute['Instance'].name}{utils.returnIdSeparator()}{identifier}{suffix}"
+    excType, excValue, excTrace = RuntimeError, RuntimeError("Model returned no evaluation"), None
     if self.parallelStrategy == 1:
       # we evaluate the model directly
       try:
@@ -794,9 +801,46 @@ class EnsembleModel(Dummy):
         # run the model
         inputKwargs.pop("jobHandler", None)
         modelToExecute['Instance'].submit(origInputList, samplerType, jobHandler, **inputKwargs)
-        ## wait until the model finishes, in order to get ready to run the subsequential one
-        while not jobHandler.isThisJobFinished(localIdentifier):
-          time.sleep(1.e-3)
+        ## Wait for the sub-model job to finish.
+        #
+        # Historical context (lock contention bug):
+        #   The original implementation polled isThisJobFinished() in a
+        #   while/sleep loop.  Each call acquires JobHandler.__queueLock.
+        #   With N evaluation threads (e.g. 100 GA populations) all
+        #   polling concurrently, the resulting N lock-requests/sec can
+        #   starve the single polling thread in JobHandler.startLoop(),
+        #   which also needs the lock to run fillJobQueue() and
+        #   cleanJobQueue().  When the polling thread is starved, jobs
+        #   that have already finished at the OS level never transition
+        #   from __running to __finished, causing a permanent hang.
+        #
+        # Fix:
+        #   Use a per-job threading.Event (created in reAddJob, set in
+        #   cleanJobQueue) so that waiting threads block on event.wait()
+        #   instead of acquiring the lock.  This eliminates contention
+        #   entirely on the wait path.
+        #
+        # The timeout on event.wait() serves two purposes:
+        #   1. Python's Event.wait(None) is not interruptible by Ctrl+C
+        #      or POSIX signals (CPython limitation); a finite timeout
+        #      ensures the thread periodically regains control.
+        #   2. Acts as a safety net in case the Event is somehow missed
+        #      (should not happen in normal operation).
+        #
+        # Backward compatibility:
+        #   If getJobEvent() returns None (unexpected), we fall back to
+        #   the original polling loop so that non-standard JobHandler
+        #   subclasses or configurations still work.
+        jobEvent = jobHandler.getJobEvent(localIdentifier)
+        if jobEvent is not None:
+          while not jobEvent.wait(timeout=30.0):
+            pass
+        else:
+          # Fallback: original polling (should not be reached in normal use)
+          self.raiseAWarning(f'No Event found for job "{localIdentifier}", '
+                             f'falling back to polling-based wait')
+          while not jobHandler.isThisJobFinished(localIdentifier):
+            time.sleep(1.0)
         moveOn = True
       # get job that just finished to gather the results
       finishedRun = jobHandler.getFinished(jobIdentifier = localIdentifier, uniqueHandler=f"{self.name}{identifier}{suffix}")
@@ -808,23 +852,35 @@ class EnsembleModel(Dummy):
           # the failure happened at the input creation stage
           excType, excValue, excTrace = IOError, IOError("Failure happened at the input creation stage. See trace above"), None
         evaluation = None
-        # the model failed
-        for modelToRemove in list(set(self.orderList) - set([modelToExecute['Instance'].name])):
-          jobHandler.getFinished(jobIdentifier = f"{modelToRemove}{utils.returnIdSeparator()}{identifier}{suffix}",
-                                 uniqueHandler = f"{self.name}{identifier}{suffix}")
+        # the model failed — clean up only models that were submitted
+        # BEFORE the failed model (they may be running or finished).
+        # Models AFTER the failed one in orderList were never submitted,
+        # so calling getFinished for them would block indefinitely.
+        failedModelIdx = self.orderList.index(modelToExecute['Instance'].name)
+        for modelToRemove in self.orderList[:failedModelIdx]:
+          try:
+            jobHandler.getFinished(jobIdentifier = f"{modelToRemove}{utils.returnIdSeparator()}{identifier}{suffix}",
+                                   uniqueHandler = f"{self.name}{identifier}{suffix}")
+          except Exception:
+            pass  # best-effort cleanup
 
       else:
         # collect the target evaluation
         modelToExecute['Instance'].collectOutput(finishedRun[0],inRunTargetEvaluations)
 
-    if not evaluation:
-      # the model failed
+    if evaluation is None:
+      # A failed sub-model should make the enclosing EnsembleModel job fail the
+      # same way a standalone Code model fails: return no evaluation and let the
+      # JobHandler/MultiRun failure-handling path manage retries or failed runs.
+      # Raising here bypasses that generic path and can leave nested ensemble
+      # runs stuck with unclaimed internal jobs.
       import traceback
       msg = io.StringIO()
       traceback.print_exception(excType, excValue, excTrace, limit=10, file=msg)
       msg = msg.getvalue().replace('\n', '\n        ')
-      self.raiseAnError(RuntimeError, f'The Model "{modelToExecute["Instance"].name}" id "{localIdentifier}" '+
-                        f'failed! Trace:\n{"*"*72}\n{msg}\n{"*"*72}')
+      self.raiseAWarning(f'The Model "{modelToExecute["Instance"].name}" id "{localIdentifier}" '+
+                         f'failed! Trace:\n{"*"*72}\n{msg}\n{"*"*72}')
+      return None
     else:
       if self.parallelStrategy == 1:
         inRunTargetEvaluations.addRealization(evaluation)

--- a/ravenframework/Optimizers/GeneticAlgorithm.py
+++ b/ravenframework/Optimizers/GeneticAlgorithm.py
@@ -806,6 +806,35 @@ class GeneticAlgorithm(RavenSampled):
   ######################################################################################
 
   ## TODO: We have to estimate the max number of unique chromosomes and make sure population size doesn't exceed that number. Or should it?
+  def _coerceRealizationDataset(self, rlz, sampleCount=None):
+    """
+      Coerce dict-based realizations into Dataset form for GA processing.
+      @ In, rlz, xr.Dataset or dict, realization data to coerce
+      @ In, sampleCount, int, optional, expected number of RAVEN samples
+      @ Out, rlz, xr.Dataset, realization data in Dataset form
+    """
+    if hasattr(rlz, 'data_vars') or not isinstance(rlz, dict):
+      return rlz
+    if sampleCount is None:
+      lengths = []
+      for value in rlz.values():
+        arr = np.asarray(value)
+        if arr.ndim <= 1 and arr.size > 0:
+          lengths.append(arr.size)
+      sampleCount = max(lengths) if lengths else 1
+    data = {}
+    for var, value in rlz.items():
+      arr = np.asarray(value)
+      if arr.ndim == 0:
+        arr = arr.reshape(1)
+      if arr.ndim != 1 or arr.size == 0:
+        continue
+      if arr.size == 1 and sampleCount > 1:
+        arr = np.repeat(arr, sampleCount)
+      if arr.size == sampleCount:
+        data[var] = ('RAVEN_sample_ID', arr)
+    return xr.Dataset(data, coords={'RAVEN_sample_ID': np.arange(sampleCount)})
+
   def _useRealization(self, info, rlz):
     """
       Used to feedback the collected runs into actionable items within the sampler.
@@ -820,6 +849,7 @@ class GeneticAlgorithm(RavenSampled):
       self._closeTrajectory(t, 'cancel', 'Currently GA is single trajectory', 0)
     self.incrementIteration(traj)
 
+    rlz = self._coerceRealizationDataset(rlz)
 
     currentPopInputs = datasetToDataArray(rlz, list(self.toBeSampled))
     currentPop_objvals = []
@@ -1239,6 +1269,7 @@ class GeneticAlgorithm(RavenSampled):
       @ In, fitness, xr.DataArray, fitness values at each chromosome of the realization
       @ Out, point, dict, point used in this realization
     """
+    rlz = self._coerceRealizationDataset(rlz, len(np.atleast_1d(objectiveVal)))
     varList = list(self.toBeSampled.keys()) + self._solutionExport.getVars('input') + self._solutionExport.getVars('output')
     varList = set(varList)
     selVars = [var for var in varList if var in rlz.data_vars]
@@ -1269,6 +1300,7 @@ class GeneticAlgorithm(RavenSampled):
       @ In, constraintsV, xr.DataArray, calculated contraints value
       @ Out, point, dict, point used in this realization
     """
+    rlz = self._coerceRealizationDataset(rlz, len(np.atleast_1d(rank.data)))
     varList = set(list(self.toBeSampled.keys()) + self._solutionExport.getVars('input') + self._solutionExport.getVars('output'))
     #!varList = [var for var in varList if var not in self._objectiveVar] #!TODO: this appears to be desyncing the estimated 'final' rlzs.
     selVars = [var for var in varList if var in rlz.data_vars]

--- a/ravenframework/Optimizers/crossOverOperators/crossovers.py
+++ b/ravenframework/Optimizers/crossOverOperators/crossovers.py
@@ -30,6 +30,40 @@ import xarray as xr
 from ...utils import randomUtils
 from ...utils.SSChecker import EQChecker, SingleCycleChecker
 
+_prloDataCache = {}
+_eqCheckerCache = {}
+_singleCycleCheckerCache = {}
+
+def _getPrloData(inputFile):
+  """
+    Return cached reduced PRLO data for shuffling-scheme dispatch.
+    @ In, inputFile, str, PRLO data XML path
+    @ Out, prloData, PRLODataParser, parsed PRLO data
+  """
+  if inputFile not in _prloDataCache:
+    _prloDataCache[inputFile] = EQChecker.PRLODataParser(inputFile, verbosity='reduced')
+  return _prloDataCache[inputFile]
+
+def _getEQChecker(inputFile):
+  """
+    Return cached equilibrium-cycle checker.
+    @ In, inputFile, str, PRLO data XML path
+    @ Out, checker, EQChecker, cached checker
+  """
+  if inputFile not in _eqCheckerCache:
+    _eqCheckerCache[inputFile] = EQChecker(inputFile)
+  return _eqCheckerCache[inputFile]
+
+def _getSingleCycleChecker(inputFile):
+  """
+    Return cached single-cycle checker.
+    @ In, inputFile, str, PRLO data XML path
+    @ Out, checker, SingleCycleChecker, cached checker
+  """
+  if inputFile not in _singleCycleCheckerCache:
+    _singleCycleCheckerCache[inputFile] = SingleCycleChecker(inputFile)
+  return _singleCycleCheckerCache[inputFile]
+
 
 # @profile
 def onePointCrossover(parents,**kwargs):
@@ -104,11 +138,14 @@ def uniformCrossover(parents,**kwargs):
   SCFlag = False
   if any("prlodata" in sublist for sublist in kwargs["files"]):
     inpfile = [sublist[-1] for sublist in kwargs["files"] if sublist[1]=='prlodata'][0]
-    EQObject = EQChecker(inpfile.getPath()+inpfile.getFilename())
-    EQFlag = EQObject.prloData.calculationType in ["eq_cycle","eq_uprate"]
-    SCFlag = EQObject.prloData.calculationType in ["single_cycle","single_uprate"] and EQObject.prloData.numBatches > 1
-  if SCFlag:
-    SCObject = SingleCycleChecker(inpfile.getPath()+inpfile.getFilename())
+    prloDataFile = inpfile.getPath()+inpfile.getFilename()
+    prloData = _getPrloData(prloDataFile)
+    EQFlag = prloData.calculationType in ["eq_cycle","eq_uprate"]
+    SCFlag = prloData.calculationType in ["single_cycle","single_uprate"] and prloData.numBatches > 1
+    if EQFlag:
+      EQObject = _getEQChecker(prloDataFile)
+    elif SCFlag:
+      SCObject = _getSingleCycleChecker(prloDataFile)
 
   index = 0
   parentsPairs = list(combinations(parents,2))

--- a/ravenframework/Optimizers/fitness/fitness.py
+++ b/ravenframework/Optimizers/fitness/fitness.py
@@ -134,7 +134,8 @@ def feasibleFirst(rlz, **kwargs):
   # For each objective
   for i, obj in enumerate(objVar):
       data = np.atleast_1d(rlz[obj].data)
-      worstObj = max(data) # Worst objective value for penalizing violating solutions
+      finiteData = data[np.isfinite(data)]
+      worstObj = max(finiteData) if len(finiteData) > 0 else max(data)
       fitness = np.zeros(data.shape)
       for ind in range(data.shape[0]):
           # If no contraints or all constraints are satisfied

--- a/ravenframework/Optimizers/mutators/mutators.py
+++ b/ravenframework/Optimizers/mutators/mutators.py
@@ -29,6 +29,40 @@ from operator import itemgetter
 from ...utils import utils, randomUtils
 from ...utils.SSChecker import EQChecker, SingleCycleChecker
 
+_prloDataCache = {}
+_eqCheckerCache = {}
+_singleCycleCheckerCache = {}
+
+def _getPrloData(inputFile):
+  """
+    Return cached reduced PRLO data for shuffling-scheme dispatch.
+    @ In, inputFile, str, PRLO data XML path
+    @ Out, prloData, PRLODataParser, parsed PRLO data
+  """
+  if inputFile not in _prloDataCache:
+    _prloDataCache[inputFile] = EQChecker.PRLODataParser(inputFile, verbosity='reduced')
+  return _prloDataCache[inputFile]
+
+def _getEQChecker(inputFile):
+  """
+    Return cached equilibrium-cycle checker.
+    @ In, inputFile, str, PRLO data XML path
+    @ Out, checker, EQChecker, cached checker
+  """
+  if inputFile not in _eqCheckerCache:
+    _eqCheckerCache[inputFile] = EQChecker(inputFile)
+  return _eqCheckerCache[inputFile]
+
+def _getSingleCycleChecker(inputFile):
+  """
+    Return cached single-cycle checker.
+    @ In, inputFile, str, PRLO data XML path
+    @ Out, checker, SingleCycleChecker, cached checker
+  """
+  if inputFile not in _singleCycleCheckerCache:
+    _singleCycleCheckerCache[inputFile] = SingleCycleChecker(inputFile)
+  return _singleCycleCheckerCache[inputFile]
+
 def swapMutator(offSprings, distDict, **kwargs):
   """
     This method performs the swap mutator. For each child, two genes are sampled and switched
@@ -72,7 +106,7 @@ def swapMutatorSS(offSprings, distDict, **kwargs):
   if not any("prlodata" in sublist for sublist in kwargs["files"]):
     raise ValueError("'swapMutatorSS' requires a File of type 'prlodata'.")
   inpfile = [sublist[-1] for sublist in kwargs["files"] if sublist[1]=='prlodata'][0]
-  prloData = EQChecker.PRLODataParser(inpfile.getPath()+inpfile.getFilename(), verbosity='reduced')
+  prloData = _getPrloData(inpfile.getPath()+inpfile.getFilename())
   if prloData.calculationType in ["eq_cycle","eq_uprate"]:
     return swapMutatorEQ(offSprings, distDict, **kwargs)
   elif prloData.calculationType in ["single_cycle","single_uprate"] and prloData.numBatches > 1:
@@ -95,7 +129,7 @@ def swapMutatorEQ(offSprings, distDict, **kwargs):
   EQFlag = False
   if any("prlodata" in sublist for sublist in kwargs["files"]):
     inpfile = [sublist[-1] for sublist in kwargs["files"] if sublist[1]=='prlodata'][0]
-    EQObject = EQChecker(inpfile.getPath()+inpfile.getFilename())
+    EQObject = _getEQChecker(inpfile.getPath()+inpfile.getFilename())
     symMult = EQObject.prloData.symmetricMultiplicity
     EQFlag = True if EQObject.prloData.calculationType in ["eq_cycle","eq_uprate"] else False
   if not EQFlag:
@@ -126,6 +160,19 @@ def swapMutatorEQ(offSprings, distDict, **kwargs):
         cdf2 = distDict[offSprings.coords['Gene'].values[loc2]].cdf(float(offSprings[i,loc2].values))
         children[i,loc1] = distDict[offSprings.coords['Gene'].values[loc1]].ppf(cdf2)
         children[i,loc2] = distDict[offSprings.coords['Gene'].values[loc2]].ppf(cdf1)
+        # Fresh fuel (batch 1) must point to its own destination location.
+        # Swapping two fresh genes without re-encoding can create a cross-link
+        # between fresh locations, which later shuffling-chain tracing treats
+        # as an invalid reload cycle.
+        for swapLoc in (loc1, loc2):
+          rawFAID = int(children[i, swapLoc].values)
+          decodedFA = EQObject.decodeFAID(rawFAID, EQObject.prloData.solnLen, EQObject.prloData.numBatches)
+          if decodedFA[1] == 1:
+            children[i, swapLoc] = EQObject.encodeFAID(
+              (swapLoc + 1, decodedFA[1], decodedFA[2]),
+              EQObject.prloData.solnLen,
+              EQObject.prloData.numBatches,
+            )
         # update any reloaded FA's pointing to the swapped positions
         ##  check loc1
         decodedFA = EQObject.decodeFAID(int(offSprings[i,loc1].values), EQObject.prloData.solnLen, EQObject.prloData.numBatches)
@@ -164,7 +211,7 @@ def swapMutatorSingleCycle(offSprings, distDict, **kwargs):
   if not any("prlodata" in sublist for sublist in kwargs["files"]):
     raise ValueError("'swapMutatorSingleCycle' requires a File of type 'prlodata'.")
   inpfile = [sublist[-1] for sublist in kwargs["files"] if sublist[1]=='prlodata'][0]
-  SCObject = SingleCycleChecker(inpfile.getPath()+inpfile.getFilename())
+  SCObject = _getSingleCycleChecker(inpfile.getPath()+inpfile.getFilename())
   symMult = SCObject.prloData.symmetricMultiplicity
 
   children = xr.DataArray(np.zeros((np.shape(offSprings))),

--- a/ravenframework/utils/SSChecker.py
+++ b/ravenframework/utils/SSChecker.py
@@ -108,6 +108,11 @@ class _PRLOCheckerBase():
       @ Out, str or datatype, parsed value from the PRLO data XML file.
       """
       parsedValue = root.find(tag)
+      if parsedValue is None:
+        matches = root.findall(f'.//{tag}')
+        if len(matches) > 1:
+          raise AttributeError(f"Tag {tag} in provided PRLOdata.xml file appears multiple times.")
+        parsedValue = matches[0] if matches else None
       if default == "no default":
         try:
           return datatype(parsedValue.text.strip())

--- a/ravenframework/utils/SSChecker.py
+++ b/ravenframework/utils/SSChecker.py
@@ -109,10 +109,11 @@ class _PRLOCheckerBase():
       """
       parsedValue = root.find(tag)
       if parsedValue is None:
-        matches = root.findall(f'.//{tag}')
-        if len(matches) > 1:
-          raise AttributeError(f"Tag {tag} in provided PRLOdata.xml file appears multiple times.")
-        parsedValue = matches[0] if matches else None
+        for sectionName in ('PARCS', 'Parcs', 'parcs', 'SIMULATE', 'Simulate', 'simulate', 'CORE', 'Core', 'core'):
+          sectionNode = root.find(sectionName)
+          parsedValue = sectionNode.find(tag) if sectionNode is not None else None
+          if parsedValue is not None:
+            break
       if default == "no default":
         try:
           return datatype(parsedValue.text.strip())


### PR DESCRIPTION
--------
Pull Request Description
--------
##### What issue does this change request address? (Use "#" before the issue to link it, i.e., #42.)


##### What are the significant changes in functionality due to this change request?

This PR improves robustness and performance in the GeneticAlgorithm optimizer and PRLO shuffling-scheme operators while preserving the current `SSChecker`-based upstream design.

This PR is stacked on the EnsembleModel job-completion PR. It is separated from that PR because the changes here are optimizer-specific, while the first PR is about `EnsembleModel/JobHandler` execution stability.

The changes address three practical issues:

  - GA logic can receive dict-like realization data in some execution/failure paths, while parts of the optimizer expect an `xarray.Dataset`.
  - The feasible-first fitness function can choose a non-finite objective value as the penalty reference when objective arrays contain `NaN` or `Inf`.
  - PRLO shuffling-scheme crossover/mutation repeatedly reparses the same PRLO XML input.
  - The equilibrium-cycle swap mutator can create fresh-fuel genes whose encoded source location no longer points to the destination location after a swap.

  ##### File-level summary

  `ravenframework/Optimizers/GeneticAlgorithm.py`
  - Adds a helper to coerce dict-based realizations into `xarray.Dataset` form.
  - Applies this normalization at the GA input boundary in `_useRealization()`.
  - Also applies the helper defensively in `_collectOptPoint()` and `_collectOptPointMulti()`.

  Why:
  - GA internals generally expect `xarray.Dataset` objects with `data_vars`.
  - Some RAVEN execution paths can pass dict-like realization data.
  - Normalizing inside `GeneticAlgorithm` keeps this behavior local to GA instead of broadening `gaUtils.datasetToDataArray()` for all callers.

  `ravenframework/Optimizers/fitness/fitness.py`
  - Updates `feasibleFirst()` so the penalty reference objective uses finite objective values when available.
  - Falls back to the original `max(data)` behavior only if no finite objective values exist.

  Why:
  - If `NaN` or `Inf` appears in the objective array, using `max(data)` directly can produce an invalid or misleading penalty reference.
  - The update makes constraint-violation penalty behavior more stable without changing the normal finite-data path.

  `ravenframework/Optimizers/crossOverOperators/crossovers.py`
  - Adds file-path-based caches for:
    - reduced PRLO XML parser data,
    - equilibrium-cycle checker,
    - single-cycle checker.
  - Uses the cached objects in `uniformCrossover()` dispatch.
  - Preserves the existing single-cycle crossover path.

  Why:
  - Large GA runs repeatedly call crossover operators using the same PRLO XML input.
  - Re-parsing the same XML and rebuilding checker objects adds avoidable overhead.

  `ravenframework/Optimizers/mutators/mutators.py`
  - Keeps both equilibrium-cycle and single-cycle mutation paths.
  - Adds file-path-based caches for:
    - reduced PRLO XML parser data,
    - equilibrium-cycle checker,
    - single-cycle checker.
  - Adds an equilibrium-cycle fresh-fuel self-pointer repair in `swapMutatorEQ()`.

  Why:
  - The cache avoids repeated PRLO XML parsing and checker construction during GA mutation.
  - For equilibrium-cycle genomes, fresh fuel is encoded with batch 1 and should point to its own destination location.

  ##### Design notes

This PR does not modify `ravenframework/utils/gaUtils.py`. The dict-to-Dataset normalization is kept inside `GeneticAlgorithm` so the change is limited to the optimizer path that needs it.

  This PR does not remove or weaken single-cycle/Nth-cycle shuffling-scheme support.

----------------
For Change Control Board: Change Request Review
----------------
The following review must be completed by an authorized member of the Change Control Board.
- [ ] 1. Review all computer code.
- [ ] 2. If any changes occur to the input syntax, there must be an accompanying change to the user manual and xsd schema. If the input syntax change deprecates existing input files, a conversion script needs to be added (see Conversion Scripts).
- [ ] 3. Make sure the Python code and commenting standards are respected (camelBack, etc.) - See on the [wiki](https://github.com/idaholab/raven/wiki/RAVEN-Code-Standards#python) for details.
- [ ] 4. Automated Tests should pass, including run_tests, pylint, manual building and xsd tests. If there are changes to Simulation.py or JobHandler.py the qsub tests must pass.
- [ ] 5. If significant functionality is added, there must  be tests added to check this. Tests should cover all possible options.  Multiple short tests are preferred over one large test. If new development on the internal JobHandler parallel system is performed, a cluster test must be added setting, in <RunInfo> XML block, the node ```<internalParallel>``` to True.
- [ ] 6. If the change modifies or adds a requirement or a requirement based test case, the Change Control Board's Chair or designee also needs to approve the change.  The requirements and the requirements test shall be in sync.
- [ ] 7. The merge request must reference an issue.  If the issue is closed, the issue close checklist shall be done.
- [ ] 8. If an analytic test is changed/added is the the analytic documentation updated/added?
- [ ] 9. If any test used as a basis for documentation examples (currently found in `raven/tests/framework/user_guide` and `raven/docs/workshop`) have been changed, the associated documentation must be reviewed and assured the text matches the example.

